### PR TITLE
Add "users" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@ AppStream MetaInfo Creator
 AppStream is a cross-distro effort for providing metadata for software in the (Linux) ecosystem. It provides a convenient way
 to get information about not installed software, and is one of the building blocks for software centers.
 
-This repository contains an Angular (9+) web application intended to make it very easy for users to generate MetaInfo files
-to ship with their software.
+## Users
+
+Please use the hosted instance: https://www.freedesktop.org/software/appstream/metainfocreator/
 
 ## Developers
+
+This repository contains an Angular (9+) web application intended to make it very easy for users to generate MetaInfo files
+to ship with their software.
 
 ### Development server
 


### PR DESCRIPTION
This PR adds a "users" section that points to the hosted instance at  https://www.freedesktop.org/software/appstream/metainfocreator/.